### PR TITLE
Deck check page

### DIFF
--- a/components/DeckCheck/index.tsx
+++ b/components/DeckCheck/index.tsx
@@ -1,0 +1,91 @@
+import { FC, useState } from 'react'
+import {
+  InputGroup,
+  InputRightElement,
+  Textarea,
+  List,
+  ListItem,
+  Link
+} from '@chakra-ui/react'
+import {
+  CheckCircleIcon,
+  NotAllowedIcon,
+  ExternalLinkIcon
+} from '@chakra-ui/icons'
+import type { LegalCards } from '@/utils/dataTypes'
+import { useIsLegal } from '@/hooks/useIsLegal'
+
+interface Props {
+  legalcards: LegalCards
+}
+
+const DeckCheck: FC<Props> = (props) => {
+  const legalCards = props.legalcards
+  const { isLegal } = useIsLegal(legalCards)
+  const [mainDeck, setMainDeck] = useState<{ name: string, legal: boolean }[]>([])
+
+  const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const { value } = event.target
+    const newSearchBox = value
+    // .trim().toLowerCase()
+    if (newSearchBox.length < 1) {
+      return
+    }
+    const newMainDeck = value.split("\n").filter((line) => line.trim().length > 0).map((line) => {
+      const isLegalRet = isLegal(line.toLowerCase())
+      console.log(line, isLegalRet)
+      return { name: isLegalRet.exactMatch ?? line, legal: isLegalRet.legal }
+    })
+    setMainDeck(newMainDeck)
+    console.log("newMainDeck", newMainDeck)
+    if (typeof newSearchBox == 'string') {
+    }
+  }
+
+  const deckNotLegal = () => mainDeck.filter(card => !card.legal).length > 0
+
+  const placeholderIndex = ~~(
+    Math.random() * Object.keys(legalCards.name).length
+  )
+  const placeholder = legalCards.name[placeholderIndex]
+
+  return (
+    <>
+      <InputGroup mt="2em">
+        <Textarea
+          placeholder={placeholder}
+          rows={15}
+          onChange={handleChange}
+        />
+        <InputRightElement>
+          {deckNotLegal() ? (
+            <NotAllowedIcon color="red.500" />
+          ) : (
+            <CheckCircleIcon color="green.500" />
+          )}
+        </InputRightElement>
+      </InputGroup>
+      <List spacing={3} mt="1em">
+        {mainDeck.map((card) => {
+          return (
+            <ListItem key={card.name}>
+              {card.legal ? <><CheckCircleIcon color="green.500" /> &nbsp;
+                <Link
+                  href={
+                    'https://scryfall.com/search?q=' +
+                    encodeURIComponent('prefer:oldest !"' + card + '"')
+                  }
+                  isExternal
+                >
+                  {card.name} <ExternalLinkIcon mx="2px" />
+                </Link></>
+                : <><NotAllowedIcon color="red.500" /> {card.name}</>}
+            </ListItem>
+          )
+        })}
+      </List>
+    </>
+  )
+}
+
+export { DeckCheck }

--- a/components/DeckCheck/index.tsx
+++ b/components/DeckCheck/index.tsx
@@ -33,14 +33,14 @@ const DeckCheck: FC<Props> = (props) => {
   const handleLangSwitch = (event: React.ChangeEvent<HTMLInputElement>) => {
     const lang = event.target.checked ? 'ja' : 'en'
     setCardLang(lang)
-    validateDeckList(textAreaInput, lang)
+    validateDeckList(lang, textAreaInput)
   }
   const handleListChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
     const { value } = event.target
-    validateDeckList(value, cardLang)
+    validateDeckList(cardLang, value)
     setTextAreaInput(value)
   }
-  const validateDeckList = ((newSearchBox?: string, lang: string) => {
+  const validateDeckList = ((lang: string, newSearchBox?: string,) => {
     if (newSearchBox === undefined || newSearchBox.length < 1) {
       return
     }

--- a/components/DeckCheck/index.tsx
+++ b/components/DeckCheck/index.tsx
@@ -66,20 +66,10 @@ const DeckCheck: FC<Props> = (props) => {
         </InputRightElement>
       </InputGroup>
       <List spacing={3} mt="1em">
-        {mainDeck.map((card) => {
+        {mainDeck.filter((card) => !card.legal).map((card) => {
           return (
             <ListItem key={card.name}>
-              {card.legal ? <><CheckCircleIcon color="green.500" /> &nbsp;
-                <Link
-                  href={
-                    'https://scryfall.com/search?q=' +
-                    encodeURIComponent('prefer:oldest !"' + card + '"')
-                  }
-                  isExternal
-                >
-                  {card.name} <ExternalLinkIcon mx="2px" />
-                </Link></>
-                : <><NotAllowedIcon color="red.500" /> {card.name}</>}
+              <NotAllowedIcon color="red.500" /> {card.name}
             </ListItem>
           )
         })}

--- a/components/DeckCheck/index.tsx
+++ b/components/DeckCheck/index.tsx
@@ -1,16 +1,14 @@
 import { FC, useState } from 'react'
 import {
   InputGroup,
-  InputRightElement,
   Textarea,
   List,
   ListItem,
-  Link
+  Box
 } from '@chakra-ui/react'
 import {
   CheckCircleIcon,
-  NotAllowedIcon,
-  ExternalLinkIcon
+  NotAllowedIcon
 } from '@chakra-ui/icons'
 import type { LegalCards } from '@/utils/dataTypes'
 import { useIsLegal } from '@/hooks/useIsLegal'
@@ -27,17 +25,15 @@ const DeckCheck: FC<Props> = (props) => {
   const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
     const { value } = event.target
     const newSearchBox = value
-    // .trim().toLowerCase()
     if (newSearchBox.length < 1) {
       return
     }
     const newMainDeck = value.split("\n").filter((line) => line.trim().length > 0).map((line) => {
-      const isLegalRet = isLegal(line.toLowerCase())
-      console.log(line, isLegalRet)
-      return { name: isLegalRet.exactMatch ?? line, legal: isLegalRet.legal }
+      const cardName = line.replace(/^[0-9]+ /g, '').trim()
+      const isLegalRet = isLegal(cardName.toLowerCase().trim())
+      return { name: isLegalRet.exactMatch ?? cardName, legal: isLegalRet.legal }
     })
     setMainDeck(newMainDeck)
-    console.log("newMainDeck", newMainDeck)
     if (typeof newSearchBox == 'string') {
     }
   }
@@ -50,22 +46,35 @@ const DeckCheck: FC<Props> = (props) => {
   const placeholder = legalCards.name[placeholderIndex]
 
   return (
-    <>
-      <InputGroup mt="2em">
+    <Box mt="1em">
+      <InputGroup>
+        <Box display="block">
+          {deckNotLegal() ? (
+            <>
+              <NotAllowedIcon color="red.500" />{' '}
+              This lisk is not Middle School legal
+            </>
+          ) : (
+            <>
+              <CheckCircleIcon color="green.500" />{' '}
+              This lisk is Middle School legal
+            </>
+          )}
+        </Box>
+      </InputGroup>
+      <InputGroup mt="1em">
         <Textarea
           placeholder={placeholder}
           rows={15}
           onChange={handleChange}
         />
-        <InputRightElement>
-          {deckNotLegal() ? (
-            <NotAllowedIcon color="red.500" />
-          ) : (
-            <CheckCircleIcon color="green.500" />
-          )}
-        </InputRightElement>
       </InputGroup>
-      <List spacing={3} mt="1em">
+      {deckNotLegal() && <>
+        <Box mt="1em">
+          The following cards are not Middle School legal:
+        </Box>
+      </>}
+      <List>
         {mainDeck.filter((card) => !card.legal).map((card) => {
           return (
             <ListItem key={card.name}>
@@ -74,7 +83,7 @@ const DeckCheck: FC<Props> = (props) => {
           )
         })}
       </List>
-    </>
+    </Box>
   )
 }
 

--- a/components/Header/index.tsx
+++ b/components/Header/index.tsx
@@ -4,11 +4,13 @@ import {
   Container,
   Heading,
   Link,
+  Button,
   Flex,
   Spacer,
   Icon,
   Image
 } from '@chakra-ui/react'
+import NextLink from 'next/link'
 import { AiFillTwitterCircle, AiFillGithub } from 'react-icons/ai'
 
 const Header: FC = () => {
@@ -27,6 +29,18 @@ const Header: FC = () => {
             <Heading size="xl" color="blue.500">
               Middle School Tutor
             </Heading>
+          </Box>
+          <Box p={2}>
+            <NextLink href="/" p={4}>
+              <Button variant='ghost' size='sm'>
+                Card Search
+              </Button>
+            </NextLink>
+            <NextLink href="/deckcheck" p={4}>
+              <Button variant='ghost' size='sm'>
+                Deck Check
+              </Button>
+            </NextLink>
           </Box>
           <Spacer />
           <Box p={2}>

--- a/components/Header/index.tsx
+++ b/components/Header/index.tsx
@@ -31,12 +31,12 @@ const Header: FC = () => {
             </Heading>
           </Box>
           <Box p={2}>
-            <NextLink href="/" p={4}>
+            <NextLink href="/">
               <Button variant='ghost' size='sm'>
                 Card Search
               </Button>
             </NextLink>
-            <NextLink href="/deckcheck" p={4}>
+            <NextLink href="/deckcheck">
               <Button variant='ghost' size='sm'>
                 Deck Check
               </Button>

--- a/hooks/useIsLegal.ts
+++ b/hooks/useIsLegal.ts
@@ -1,14 +1,18 @@
 import type { LegalCards, ListAsProps } from '@/utils/dataTypes'
 
 const useIsLegal = (legalCards: LegalCards) => {
-  const isLegal = (newSearchBox: string) => {
-    const englishMatch = inObject(newSearchBox, legalCards.name)
-    if (englishMatch.length > 0) {
-      return { legal: true, exactMatch: englishMatch }
+  const isLegal = (newSearchBox: string, lang?: string) => {
+    if (lang === undefined || lang == 'en') {
+      const englishMatch = inObject(newSearchBox, legalCards.name)
+      if (englishMatch.length > 0) {
+        return { legal: true, exactMatch: englishMatch, lang: 'en' }
+      }
     }
-    const japaneseMatch = inObject(newSearchBox, legalCards.name_ja)
-    if (japaneseMatch.length > 0) {
-      return { legal: true, exactMatch: japaneseMatch }
+    if (lang === undefined || lang == 'ja') {
+      const japaneseMatch = inObject(newSearchBox, legalCards.name_ja)
+      if (japaneseMatch.length > 0) {
+        return { legal: true, exactMatch: japaneseMatch, lang: 'ja' }
+      }
     }
     return { legal: false }
   }

--- a/pages/deckcheck.tsx
+++ b/pages/deckcheck.tsx
@@ -31,8 +31,8 @@ export const getStaticProps: GetStaticProps = async () => {
   const res = await fetch(
     // For offline builds, on the `middleschool-cardlist` repo directory:
     // python3 -m http.server
-    'http://127.0.0.1:8000/output/middleschool.json'
-    // 'https://alecrem.github.io/middleschool-cardlist/output/middleschool.json'
+    // 'http://127.0.0.1:8000/output/middleschool.json'
+    'https://alecrem.github.io/middleschool-cardlist/output/middleschool.json'
   )
   const legalCards: LegalCards = await res.json()
 

--- a/pages/deckcheck.tsx
+++ b/pages/deckcheck.tsx
@@ -1,0 +1,46 @@
+import type { NextPage } from 'next'
+import { GetStaticProps } from 'next'
+import { Container, Heading, Text, Link } from '@chakra-ui/react'
+import { Header } from '@/components/Header'
+import { DeckCheck } from '@/components/DeckCheck'
+import type { CardsProps, LegalCards } from '@/utils/dataTypes'
+
+const DeckCheckPage: NextPage = (props) => {
+  const legalCards = (props as CardsProps).legalCards
+
+  return (
+    <>
+      <Header />
+      <Container maxW="container.sm" mt="2em">
+        <Heading as="h1" size="2xl">
+          Deck Check
+        </Heading>
+        <Text mt="1em">
+          Paste or type your deck list here to confirm that every card is{' '}
+          <Link href="https://www.eternalcentral.com/middleschoolrules/">
+            Middle School legal
+          </Link>.
+        </Text>
+        <DeckCheck legalcards={legalCards} />
+      </Container>
+    </>
+  )
+}
+
+export const getStaticProps: GetStaticProps = async () => {
+  const res = await fetch(
+    // For offline builds, on the `middleschool-cardlist` repo directory:
+    // python3 -m http.server
+    'http://127.0.0.1:8000/output/middleschool.json'
+    // 'https://alecrem.github.io/middleschool-cardlist/output/middleschool.json'
+  )
+  const legalCards: LegalCards = await res.json()
+
+  return {
+    props: {
+      legalCards
+    }
+  }
+}
+
+export default DeckCheckPage


### PR DESCRIPTION
Close #20

- Fist implementation of deck list legality check
- Only show illegal cards on list
- Fix: deckcheck now loading online dataset
- Accept lines with a number of copies in front of the card 18 Mountain 2 山 4 Ball Lightning 4 稲妻 4 Necropotence 4 Lion's Eye Diamond
- Switch between English and Japanese card list validation
- Add basic navigation links
