### PR TITLE
Japanese placeholder deck list

### DIFF
--- a/components/DeckCheck/index.tsx
+++ b/components/DeckCheck/index.tsx
@@ -62,7 +62,10 @@ const DeckCheck: FC<Props> = (props) => {
   const placeholderIndex = ~~(
     Math.random() * Object.keys(legalCards.name).length
   )
-  const placeholder = legalCards.name[placeholderIndex]
+  const placeholder =
+    cardLang === 'ja' && legalCards.name_ja[placeholderIndex] !== null
+      ? legalCards.name_ja[placeholderIndex]
+      : legalCards.name[placeholderIndex]
 
   return (
     <Box mt="1em">

--- a/components/DeckCheck/index.tsx
+++ b/components/DeckCheck/index.tsx
@@ -7,10 +7,7 @@ import {
   Switch,
   Box
 } from '@chakra-ui/react'
-import {
-  CheckCircleIcon,
-  NotAllowedIcon
-} from '@chakra-ui/icons'
+import { CheckCircleIcon, NotAllowedIcon } from '@chakra-ui/icons'
 import type { LegalCards } from '@/utils/dataTypes'
 import { useIsLegal } from '@/hooks/useIsLegal'
 
@@ -40,21 +37,27 @@ const DeckCheck: FC<Props> = (props) => {
     validateDeckList(cardLang, value)
     setTextAreaInput(value)
   }
-  const validateDeckList = ((lang: string, newSearchBox?: string,) => {
+  const validateDeckList = (lang: string, newSearchBox?: string) => {
     if (newSearchBox === undefined || newSearchBox.length < 1) {
       return
     }
-    const newMainDeck = newSearchBox.split("\n").filter((line) => line.trim().length > 0).map((line) => {
-      const cardName = line.replace(/^[0-9]+ /g, '').trim()
-      const isLegalRet = isLegal(cardName.toLowerCase().trim(), lang)
-      return { name: isLegalRet.exactMatch ?? cardName, legal: isLegalRet.legal, lang: isLegalRet.lang }
-    })
+    const newMainDeck = newSearchBox
+      .split('\n')
+      .filter((line) => line.trim().length > 0)
+      .map((line) => {
+        const cardName = line.replace(/^[0-9]+ /g, '').trim()
+        const isLegalRet = isLegal(cardName.toLowerCase().trim(), lang)
+        return {
+          name: isLegalRet.exactMatch ?? cardName,
+          legal: isLegalRet.legal,
+          lang: isLegalRet.lang
+        }
+      })
     setMainDeck(newMainDeck)
-  })
+  }
 
-  const deckNotLegal = () => mainDeck.filter(card => !card.legal).length > 0
-  const cardLangString = () => cardLang === 'en' ? 'English' : 'Japanese'
-
+  const deckNotLegal = () => mainDeck.filter((card) => !card.legal).length > 0
+  const cardLangString = () => (cardLang === 'en' ? 'English' : 'Japanese')
 
   const placeholderIndex = ~~(
     Math.random() * Object.keys(legalCards.name).length
@@ -74,13 +77,13 @@ const DeckCheck: FC<Props> = (props) => {
         <Box mt="1em">
           {deckNotLegal() ? (
             <>
-              <NotAllowedIcon color="red.500" />{' '}
-              This {cardLangString()} list is not Middle School legal
+              <NotAllowedIcon color="red.500" /> This {cardLangString()} list is
+              not Middle School legal
             </>
           ) : (
             <>
-              <CheckCircleIcon color="green.500" />{' '}
-              This {cardLangString()} list is Middle School legal
+              <CheckCircleIcon color="green.500" /> This {cardLangString()} list
+              is Middle School legal
             </>
           )}
         </Box>
@@ -94,19 +97,24 @@ const DeckCheck: FC<Props> = (props) => {
           onChange={handleListChange}
         />
       </InputGroup>
-      {deckNotLegal() && <>
-        <Box mt="1em">
-          The following {cardLangString()} card names are not Middle School legal:
-        </Box>
-      </>}
+      {deckNotLegal() && (
+        <>
+          <Box mt="1em">
+            The following {cardLangString()} card names are not Middle School
+            legal:
+          </Box>
+        </>
+      )}
       <List>
-        {mainDeck.filter((card) => !card.legal).map((card) => {
-          return (
-            <ListItem key={card.name}>
-              <NotAllowedIcon color="red.500" /> {card.name}
-            </ListItem>
-          )
-        })}
+        {mainDeck
+          .filter((card) => !card.legal)
+          .map((card) => {
+            return (
+              <ListItem key={card.name}>
+                <NotAllowedIcon color="red.500" /> {card.name}
+              </ListItem>
+            )
+          })}
       </List>
     </Box>
   )

--- a/components/DeckCheck/index.tsx
+++ b/components/DeckCheck/index.tsx
@@ -63,9 +63,10 @@ const DeckCheck: FC<Props> = (props) => {
     Math.random() * Object.keys(legalCards.name).length
   )
   const placeholder =
-    cardLang === 'ja' && legalCards.name_ja[placeholderIndex] !== null
+    '4 ' +
+    (cardLang === 'ja' && legalCards.name_ja[placeholderIndex] !== null
       ? legalCards.name_ja[placeholderIndex]
-      : legalCards.name[placeholderIndex]
+      : legalCards.name[placeholderIndex])
 
   return (
     <Box mt="1em">

--- a/components/Header/index.tsx
+++ b/components/Header/index.tsx
@@ -32,12 +32,12 @@ const Header: FC = () => {
           </Box>
           <Box p={2}>
             <NextLink href="/">
-              <Button variant='ghost' size='sm'>
+              <Button variant="ghost" size="sm">
                 Card Search
               </Button>
             </NextLink>
             <NextLink href="/deckcheck">
-              <Button variant='ghost' size='sm'>
+              <Button variant="ghost" size="sm">
                 Deck Check
               </Button>
             </NextLink>

--- a/components/Search/index.tsx
+++ b/components/Search/index.tsx
@@ -52,10 +52,7 @@ const Search: FC<Props> = (props) => {
   return (
     <>
       <InputGroup mt="2em">
-        <Input
-          placeholder={placeholder}
-          onChange={handleChange}
-        />
+        <Input placeholder={placeholder} onChange={handleChange} />
         <InputRightElement>
           {cardIsLegal ? (
             <>

--- a/pages/deckcheck.tsx
+++ b/pages/deckcheck.tsx
@@ -19,7 +19,8 @@ const DeckCheckPage: NextPage = (props) => {
           Paste or type your deck list here to confirm that every card is{' '}
           <Link href="https://www.eternalcentral.com/middleschoolrules/">
             Middle School legal
-          </Link>.
+          </Link>
+          .
         </Text>
         <DeckCheck legalcards={legalCards} />
       </Container>


### PR DESCRIPTION
Close #24

- Bonus: Prettier formatted
- Use Japanese name for placeholder when Japanese card names selected
- Add "4 " in front of the card name on the placeholder
