### PR TITLE
Allow mixing card languages within list

### DIFF
--- a/components/DeckCheck/index.tsx
+++ b/components/DeckCheck/index.tsx
@@ -56,13 +56,13 @@ const DeckCheck: FC<Props> = (props) => {
         <Box mt="1em">
           {deckNotLegal() ? (
             <>
-              <NotAllowedIcon color="red.500" /> This list is not Middle School
-              legal
+              <NotAllowedIcon color="red.500" /> This is not a list of Middle
+              School-legal cards
             </>
           ) : (
             <>
-              <CheckCircleIcon color="green.500" /> This list is Middle School
-              legal
+              <CheckCircleIcon color="green.500" /> This is a list of Middle
+              School-legal cards
             </>
           )}
         </Box>

--- a/components/DeckCheck/index.tsx
+++ b/components/DeckCheck/index.tsx
@@ -1,12 +1,5 @@
 import { FC, useState } from 'react'
-import {
-  InputGroup,
-  Textarea,
-  List,
-  ListItem,
-  Switch,
-  Box
-} from '@chakra-ui/react'
+import { InputGroup, Textarea, List, ListItem, Box } from '@chakra-ui/react'
 import { CheckCircleIcon, NotAllowedIcon } from '@chakra-ui/icons'
 import type { LegalCards } from '@/utils/dataTypes'
 import { useIsLegal } from '@/hooks/useIsLegal'
@@ -24,20 +17,14 @@ const DeckCheck: FC<Props> = (props) => {
   const legalCards = props.legalcards
   const { isLegal } = useIsLegal(legalCards)
   const [mainDeck, setMainDeck] = useState<CardListItem[]>([])
-  const [cardLang, setCardLang] = useState('en')
   const [textAreaInput, setTextAreaInput] = useState<string>()
 
-  const handleLangSwitch = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const lang = event.target.checked ? 'ja' : 'en'
-    setCardLang(lang)
-    validateDeckList(lang, textAreaInput)
-  }
   const handleListChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
     const { value } = event.target
-    validateDeckList(cardLang, value)
+    validateDeckList(value)
     setTextAreaInput(value)
   }
-  const validateDeckList = (lang: string, newSearchBox?: string) => {
+  const validateDeckList = (newSearchBox?: string) => {
     if (newSearchBox === undefined || newSearchBox.length < 1) {
       return
     }
@@ -46,7 +33,7 @@ const DeckCheck: FC<Props> = (props) => {
       .filter((line) => line.trim().length > 0)
       .map((line) => {
         const cardName = line.replace(/^[0-9]+ /g, '').trim()
-        const isLegalRet = isLegal(cardName.toLowerCase().trim(), lang)
+        const isLegalRet = isLegal(cardName.toLowerCase().trim())
         return {
           name: isLegalRet.exactMatch ?? cardName,
           legal: isLegalRet.legal,
@@ -57,37 +44,25 @@ const DeckCheck: FC<Props> = (props) => {
   }
 
   const deckNotLegal = () => mainDeck.filter((card) => !card.legal).length > 0
-  const cardLangString = () => (cardLang === 'en' ? 'English' : 'Japanese')
 
   const placeholderIndex = ~~(
     Math.random() * Object.keys(legalCards.name).length
   )
-  const placeholder =
-    '4 ' +
-    (cardLang === 'ja' && legalCards.name_ja[placeholderIndex] !== null
-      ? legalCards.name_ja[placeholderIndex]
-      : legalCards.name[placeholderIndex])
+  const placeholder = '4 ' + legalCards.name[placeholderIndex]
 
   return (
     <Box mt="1em">
       <InputGroup>
-        <Box>
-          <Switch onChange={handleLangSwitch}>
-            {cardLangString()} card names
-          </Switch>
-        </Box>
-      </InputGroup>
-      <InputGroup>
         <Box mt="1em">
           {deckNotLegal() ? (
             <>
-              <NotAllowedIcon color="red.500" /> This {cardLangString()} list is
-              not Middle School legal
+              <NotAllowedIcon color="red.500" /> This list is not Middle School
+              legal
             </>
           ) : (
             <>
-              <CheckCircleIcon color="green.500" /> This {cardLangString()} list
-              is Middle School legal
+              <CheckCircleIcon color="green.500" /> This list is Middle School
+              legal
             </>
           )}
         </Box>
@@ -104,8 +79,7 @@ const DeckCheck: FC<Props> = (props) => {
       {deckNotLegal() && (
         <>
           <Box mt="1em">
-            The following {cardLangString()} card names are not Middle School
-            legal:
+            The following card names are not Middle School legal:
           </Box>
         </>
       )}

--- a/components/Footer/index.tsx
+++ b/components/Footer/index.tsx
@@ -2,8 +2,8 @@ import { Container, Text } from '@chakra-ui/react'
 
 function Footer() {
   return (
-    <Container maxW="container.sm" mt="2em">
-      <Text>
+    <Container maxW="container.sm" my="2em">
+      <Text fontSize="xs">
         Portions of Middle School Tutor are unofficial Fan Content permitted
         under the Wizards of the Coast Fan Content Policy. The literal and
         graphical information presented on this site about Magic: The Gathering,
@@ -14,9 +14,8 @@ function Footer() {
         Coast. The GitHub and Twitter logos are copyright their respective
         owners. Middle School Tutor is not produced by or endorsed by these
         services.
-        <br />
-        All other content MIT licensed since 2022 by alecrem.
       </Text>
+      <Text>All other content MIT licensed since 2022 by alecrem.</Text>
     </Container>
   )
 }

--- a/components/Header/index.tsx
+++ b/components/Header/index.tsx
@@ -38,7 +38,7 @@ const Header: FC = () => {
             </NextLink>
             <NextLink href="/deckcheck">
               <Button variant="ghost" size="sm">
-                Deck Check
+                List Check
               </Button>
             </NextLink>
           </Box>

--- a/pages/deckcheck.tsx
+++ b/pages/deckcheck.tsx
@@ -14,10 +14,10 @@ const DeckCheckPage: NextPage = (props) => {
       <Header />
       <Container maxW="container.sm" mt="2em">
         <Heading as="h1" size="2xl">
-          Deck Check
+          List Check
         </Heading>
         <Text mt="1em">
-          Paste or type your deck list here to confirm that every card is{' '}
+          Paste or type your list here to confirm that every card in it is{' '}
           <Link href="https://www.eternalcentral.com/middleschoolrules/">
             Middle School legal
           </Link>


### PR DESCRIPTION
Close #26

- Allow mixing card languages within list
- Bonus: styled footer content
